### PR TITLE
Allow custom stack configs

### DIFF
--- a/net.go
+++ b/net.go
@@ -42,7 +42,7 @@ var MTU uint32 = enet.MTU
 
 // Interface represents an Ethernet interface instance.
 type Interface struct {
-	nicid tcpip.NICID
+	NICID tcpip.NICID
 	NIC   *NIC
 
 	Stack *stack.Stack
@@ -70,7 +70,7 @@ func (iface *Interface) configure(mac string, ip tcpip.AddressWithPrefix, gw tcp
 	linkEP := stack.LinkEndpoint(iface.Link)
 	iface.Link.LinkEPCapabilities |= stack.CapabilityResolutionRequired
 
-	if err := iface.Stack.CreateNIC(iface.nicid, linkEP); err != nil {
+	if err := iface.Stack.CreateNIC(iface.NICID, linkEP); err != nil {
 		return fmt.Errorf("%v", err)
 	}
 
@@ -79,7 +79,7 @@ func (iface *Interface) configure(mac string, ip tcpip.AddressWithPrefix, gw tcp
 		AddressWithPrefix: ip,
 	}
 
-	if err := iface.Stack.AddProtocolAddress(iface.nicid, protocolAddr, stack.AddressProperties{}); err != nil {
+	if err := iface.Stack.AddProtocolAddress(iface.NICID, protocolAddr, stack.AddressProperties{}); err != nil {
 		return fmt.Errorf("%v", err)
 	}
 
@@ -87,13 +87,13 @@ func (iface *Interface) configure(mac string, ip tcpip.AddressWithPrefix, gw tcp
 
 	rt = append(rt, tcpip.Route{
 		Destination: protocolAddr.AddressWithPrefix.Subnet(),
-		NIC:         iface.nicid,
+		NIC:         iface.NICID,
 	})
 
 	rt = append(rt, tcpip.Route{
 		Destination: header.IPv4EmptySubnet,
 		Gateway:     gw,
-		NIC:         iface.nicid,
+		NIC:         iface.NICID,
 	})
 
 	iface.Stack.SetRouteTable(rt)
@@ -112,13 +112,13 @@ func (iface *Interface) EnableICMP() error {
 		return fmt.Errorf("endpoint error (icmp): %v", err)
 	}
 
-	addr, tcpErr := iface.Stack.GetMainNICAddress(iface.nicid, ipv4.ProtocolNumber)
+	addr, tcpErr := iface.Stack.GetMainNICAddress(iface.NICID, ipv4.ProtocolNumber)
 
 	if tcpErr != nil {
 		return fmt.Errorf("couldn't get NIC IP address: %v", tcpErr)
 	}
 
-	fullAddr := tcpip.FullAddress{Addr: addr.Address, Port: 0, NIC: iface.nicid}
+	fullAddr := tcpip.FullAddress{Addr: addr.Address, Port: 0, NIC: iface.NICID}
 
 	if err := ep.Bind(fullAddr); err != nil {
 		return fmt.Errorf("bind error (icmp endpoint): ", err)
@@ -130,13 +130,13 @@ func (iface *Interface) EnableICMP() error {
 // ListenerTCP4 returns a net.Listener capable of accepting IPv4 TCP
 // connections for the argument port.
 func (iface *Interface) ListenerTCP4(port uint16) (net.Listener, error) {
-	addr, tcpErr := iface.Stack.GetMainNICAddress(iface.nicid, ipv4.ProtocolNumber)
+	addr, tcpErr := iface.Stack.GetMainNICAddress(iface.NICID, ipv4.ProtocolNumber)
 
 	if tcpErr != nil {
 		return nil, fmt.Errorf("couldn't get NIC IP address: %v", tcpErr)
 	}
 
-	fullAddr := tcpip.FullAddress{Addr: addr.Address, Port: port, NIC: iface.nicid}
+	fullAddr := tcpip.FullAddress{Addr: addr.Address, Port: port, NIC: iface.NICID}
 	listener, err := gonet.ListenTCP(iface.Stack, fullAddr, ipv4.ProtocolNumber)
 
 	if err != nil {
@@ -224,7 +224,7 @@ func Init(nic *enet.ENET, ip string, netmask string, mac string, gateway string,
 	}
 
 	iface = &Interface{
-		nicid: tcpip.NICID(id),
+		NICID: tcpip.NICID(id),
 	}
 
 	ipAddr := tcpip.AddressWithPrefix{

--- a/net.go
+++ b/net.go
@@ -65,10 +65,6 @@ var DefaultStackOptions = &stack.Options{
 
 func (iface *Interface) configure(opts Options) (err error) {
 	iface.Stack = stack.New(*opts.StackOptions)
-	/*
-
-		})
-	*/
 	iface.Link = channel.New(256, MTU, opts.MAC)
 	linkEP := stack.LinkEndpoint(iface.Link)
 	iface.Link.LinkEPCapabilities |= stack.CapabilityResolutionRequired
@@ -262,18 +258,28 @@ func Init(nic *enet.ENET, ip string, netmask string, mac string, gateway string,
 	})
 }
 
+// IPConfig holds IP config information.
 type IPConfig struct {
-	Address           tcpip.AddressWithPrefix
-	Gateway           tcpip.Address
-	AddressProperties stack.AddressProperties
-}
-type Options struct {
-	MAC          tcpip.LinkAddress
-	StackOptions *stack.Options
-	IPv4         *IPConfig
-	IPv6         *IPConfig
+	Address tcpip.AddressWithPrefix
+	Gateway tcpip.Address
 }
 
+// Options contains parameters for configuring the network.
+type Options struct {
+	// MAC is the link layer address to set on the stack.
+	MAC tcpip.LinkAddress
+	// StackOptions can optionally be used to pass in custom options when
+	// creating the stack. If unset, a default IPv4-only stack will be created.
+	StackOptions *stack.Options
+	// IPv4 contains configuration for the IPv4 protocol.
+	IPv4 *IPConfig
+	// IPv6 contains configuration for the IPv6 protocol.
+	IPv6 *IPConfig
+}
+
+// InitWithOptions creates a new Interface with the provided options.
+// This method allows for more control over the configuration of the TCP/IP stack which is
+// created.
 func InitWithOptions(nic *enet.ENET, id tcpip.NICID, opts Options) (*Interface, error) {
 	if opts.StackOptions == nil {
 		opts.StackOptions = DefaultStackOptions

--- a/runtime.go
+++ b/runtime.go
@@ -17,6 +17,7 @@ import (
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
+	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
 )
 
 // Socket can be used as net.SocketFunc under GOOS=tamago to allow its use
@@ -41,12 +42,14 @@ func (iface *Interface) Socket(ctx context.Context, network string, family, soty
 	switch family {
 	case syscall.AF_INET:
 		proto = ipv4.ProtocolNumber
+	case syscall.AF_INET6:
+		proto = ipv6.ProtocolNumber
 	default:
 		return nil, errors.New("unsupported address family")
 	}
 
 	switch network {
-	case "udp", "udp4":
+	case "udp", "udp4", "udp6":
 		if sotype != syscall.SOCK_DGRAM {
 			return nil, errors.New("unsupported socket type")
 		}
@@ -54,7 +57,7 @@ func (iface *Interface) Socket(ctx context.Context, network string, family, soty
 		if c, err = gonet.DialUDP(iface.Stack, &lFullAddr, &rFullAddr, proto); c != nil {
 			return
 		}
-	case "tcp", "tcp4":
+	case "tcp", "tcp4", "tcp6":
 		if sotype != syscall.SOCK_STREAM {
 			return nil, errors.New("unsupported socket type")
 		}

--- a/runtime.go
+++ b/runtime.go
@@ -16,8 +16,6 @@ import (
 
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
-	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"
-	"gvisor.dev/gvisor/pkg/tcpip/network/ipv6"
 )
 
 // Socket can be used as net.SocketFunc under GOOS=tamago to allow its use
@@ -39,12 +37,8 @@ func (iface *Interface) Socket(ctx context.Context, network string, family, soty
 		}
 	}
 
-	switch family {
-	case syscall.AF_INET:
-		proto = ipv4.ProtocolNumber
-	case syscall.AF_INET6:
-		proto = ipv6.ProtocolNumber
-	default:
+	proto, ok := iface.protos[family]
+	if !ok {
 		return nil, errors.New("unsupported address family")
 	}
 


### PR DESCRIPTION
This PR adds an alternative `InitWithOpts` func which allows the caller to have more freedom on how the network stack is configured, and lays the ground for supporting IPv6.

